### PR TITLE
fixed application crashing bug and added logging functionality.

### DIFF
--- a/AtlasLogger/CMakeLists.txt
+++ b/AtlasLogger/CMakeLists.txt
@@ -1,0 +1,13 @@
+project(AtlasLogger)
+
+add_library(AtlasLogger STATIC atlaslogger.cpp)
+target_include_directories(
+  AtlasLogger PRIVATE 
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+if(MSVC)
+  target_compile_options(AtlasLogger PUBLIC "/Zc:__cplusplus")
+endif()
+
+add_library(Atlas::Logger ALIAS AtlasLogger)

--- a/AtlasLogger/atlaslogger.cpp
+++ b/AtlasLogger/atlaslogger.cpp
@@ -1,0 +1,57 @@
+#include "atlaslogger.hpp"
+
+#include <fstream>
+
+namespace AtlasLogger
+{
+  Logger::Logger(const std::string_view logFilePath, const std::string_view loggerClassName)
+    : m_logFilePath(logFilePath), m_loggerClassName(loggerClassName)
+  {
+    this->initializeLogFile();
+  }
+
+  auto Logger::initializeLogFile() -> void
+  {
+    if(!std::filesystem::exists(m_logFilePath.parent_path()))
+    {
+      std::filesystem::create_directories(m_logFilePath.parent_path());
+    }
+
+    if(!std::filesystem::exists(m_logFilePath))
+    {
+      std::ofstream ofs(m_logFilePath, std::ios::app);
+      ofs << "--- Atlas Logger Initialized for " << m_loggerClassName << " ---\n";
+      ofs.close();
+    }
+    else
+    {
+      std::ofstream ofs(m_logFilePath, std::ios::app);
+      ofs << "--- New Instance of Atlas Logger Initialized for " << m_loggerClassName << " ---\n";
+      ofs.close();
+    }
+  }
+
+  auto Logger::LogMessageToDisk(
+    const LogLevel level,
+    const std::chrono::system_clock::time_point& timestamp,
+    const std::string_view message
+  ) -> void
+  {
+    std::ofstream ofs(m_logFilePath, std::ios::app);
+    if(!ofs.is_open())
+    {
+      return;
+    }
+
+    const auto timeT = std::chrono::system_clock::to_time_t(timestamp);
+
+    ofs << "[" << std::chrono::current_zone()->to_local(timestamp) << "] "
+        << "[" << LogLevelToString(level) << "] "
+        << "[" << m_loggerClassName << "] "
+        << message << "\n";
+        //<< " (at " << loc.file_name() << ":" << loc.line() << " in " << loc.function_name() << ")\n";
+
+    ofs.close();
+  }
+  
+}

--- a/AtlasLogger/atlaslogger.hpp
+++ b/AtlasLogger/atlaslogger.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <format>
+#include <cstdint>
+#include <chrono>
+#include <filesystem>
+#include <source_location>
+
+namespace AtlasLogger
+{
+  enum class LogLevel : std::uint8_t
+  {
+    Debug,
+    Info,
+    Warning,
+    Error,
+    Critical
+  };
+
+  inline const auto LogLevelToString = [](const LogLevel level) -> std::string_view
+  {
+    switch(level)
+    {
+      case LogLevel::Debug:    return "DEBUG";
+      case LogLevel::Info:     return "INFO";
+      case LogLevel::Warning:  return "WARNING";
+      case LogLevel::Error:    return "ERROR";
+      case LogLevel::Critical: return "CRITICAL";
+      default:                 return "UNKNOWN";
+    }
+  };
+
+  template<class... Args>
+  struct format_string_with_source {
+    std::format_string<Args...> fmt;
+    std::source_location loc;
+
+    template<class T>
+    requires std::convertible_to<T, std::string_view>
+    consteval format_string_with_source(
+      const T& fmt,
+      std::source_location loc = std::source_location::current()
+    ) : fmt(fmt), loc(loc) {}
+  };
+
+  class Logger
+  {
+    public:
+      Logger(const std::string_view logFilePath, const std::string_view loggerClassName);
+
+      template<typename...Args>
+      auto Log(const LogLevel level, format_string_with_source<std::type_identity_t<Args>...> fmtWithLoc, Args&&... args) -> void
+      {
+        const auto timestamp = std::chrono::system_clock::now();
+        const auto formattedMessage = std::format("{}:{} {}", fmtWithLoc.loc.file_name(), fmtWithLoc.loc.line(), std::vformat(fmtWithLoc.fmt.get(), std::make_format_args(args...)));
+        this->LogMessageToDisk(level, timestamp, formattedMessage);
+      }
+
+    private:
+      auto initializeLogFile() -> void;
+      auto LogMessageToDisk(
+        const LogLevel level,
+        const std::chrono::system_clock::time_point& timestamp,
+        const std::string_view message
+      ) -> void;
+
+      const std::filesystem::path m_logFilePath;
+      const std::string m_loggerClassName;
+
+  };
+
+} // namespace AtlasLogger

--- a/AtlasModel/model.cpp
+++ b/AtlasModel/model.cpp
@@ -1,5 +1,6 @@
 #include "model.hpp"
 #include "AtlasMessenger/atlasmessenger.hpp"
+#include "AtlasLogger/atlaslogger.hpp"
 
 #include <opencv2/core.hpp>
 #include <opencv2/highgui.hpp>
@@ -12,13 +13,48 @@
 
 #include <print>
 
+#include <expected>
+
 namespace AtlasModel
 {
   const std::unordered_map<AtlasCommon::AtlasDataSet, std::string> Model::m_dataSetPaths =
   {
-    {AtlasCommon::AtlasDataSet::LGN, "./Dataset/LGN"},
-    {AtlasCommon::AtlasDataSet::PAG, "./Dataset/PAG"}
+    {AtlasCommon::AtlasDataSet::LGN, "/Dataset/LGN"},
+    {AtlasCommon::AtlasDataSet::PAG, "/Dataset/PAG"}
   };
+
+  static AtlasLogger::Logger m_logger{std::filesystem::current_path().string() + "/Logs/Model.log", "AtlasModel::Model"};
+
+  enum class LoadDataSetResult
+  {
+    Success,
+    PathNotFound,
+    NoImagesFound
+  };
+
+  auto GetImages(const std::filesystem::path& datasetPath) -> std::expected<std::vector<AtlasImage::Image>, LoadDataSetResult>
+  {
+    auto images = std::vector<AtlasImage::Image>{};
+
+    if(!std::filesystem::exists(datasetPath))
+    {
+      // Should not happen if paths are correct
+      m_logger.Log(AtlasLogger::LogLevel::Error, "Dataset path not found: {}", datasetPath.string());
+      return std::unexpected(LoadDataSetResult::PathNotFound);
+    }
+
+    for(const auto& entry : std::filesystem::directory_iterator{datasetPath})
+    {
+      images.emplace_back(AtlasImage::Image(entry.path().string()));
+    }
+
+    if(images.empty())
+    {
+      m_logger.Log(AtlasLogger::LogLevel::Warning, "No images found in dataset path: {}", datasetPath.string());
+      return std::unexpected(LoadDataSetResult::NoImagesFound);
+    }
+    return images;
+  }
 
   Model::Model()
   {
@@ -102,16 +138,25 @@ namespace AtlasModel
     if(m_images.size() > 0)
       m_images.clear();
 
-    const std::filesystem::path dataSetPath{std::filesystem::current_path()/=m_dataSetPaths.at(dataSet)};
-    std::ranges::for_each(std::filesystem::directory_iterator{dataSetPath}, [&,this](const auto& entry)
-    {
-      m_images.emplace_back(AtlasImage::Image(entry.path().string()));
-    });
+    const auto currentPath = std::filesystem::current_path().string();
+    const auto modelPath = m_dataSetPaths.at(dataSet);
+
+    m_logger.Log(AtlasLogger::LogLevel::Info, "Loading dataset from path: {}", currentPath + modelPath);
+
+    const auto dataSetPath = std::filesystem::path{currentPath + modelPath};
+
+    m_images = GetImages(dataSetPath).value_or(std::vector<AtlasImage::Image>{});
 
     if(m_images.empty())
+    {
+      m_logger.Log(AtlasLogger::LogLevel::Error, "No images found in dataset at path: {}", dataSetPath.string());
       AtlasMessenger::Messenger::Instance().SendMessage("No images found in dataset", AtlasCommon::AtlasClasses::AtlasImageViewer);
+    }
     else
+    {
+      m_logger.Log(AtlasLogger::LogLevel::Info, "Successfully loaded {} images from dataset", m_images.size());
       AtlasMessenger::Messenger::Instance().SendMessage("Images loaded successfully", AtlasCommon::AtlasClasses::AtlasImageViewer); 
+    }
   }
 
   auto Model::HandleMessage(const char* message) -> void

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.21)
 
 project(AtlasImager)
 
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release" CACHE STRING "Available build configurations" FORCE)
+set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL")
+
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -15,6 +18,7 @@ qt_standard_project_setup()
 set(ATLASIMAGER_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
 
 add_subdirectory(AtlasGUI)
+add_subdirectory(AtlasLogger)
 add_subdirectory(AtlasImage)
 add_subdirectory(AtlasModel)
 add_subdirectory(AtlasMessenger)
@@ -31,7 +35,7 @@ endif()
 target_include_directories(AtlasImager PRIVATE ${ATLASIMAGER_ROOT_DIR})
 target_link_libraries(
   AtlasImager PUBLIC ${OpenCV_LIBS} OpenGL::GL 
-  Qt6::Core Qt6::Gui Qt6::OpenGL Qt6::Widgets Atlas::Image
+  Qt6::Core Qt6::Gui Qt6::OpenGL Qt6::Widgets Atlas::Logger Atlas::Image
   Atlas::GUI Atlas::Messenger Atlas::Model Atlas::ImageViewer
 )
 


### PR DESCRIPTION
On Windows systems, `std::filesystem::append` would completely erase the `current_path()` variable. I updated this and strictly appended to strings together when creating a new path. 

I also added logging functionality in order to properly debug the application. 